### PR TITLE
fix:source from some default value of key is not correct in the debug info

### DIFF
--- a/test_junkie/settings.py
+++ b/test_junkie/settings.py
@@ -81,7 +81,9 @@ class Settings:
         # if we have kwargs, attempt to retrieve value for the key
         if self.kwargs is not None:
             value = self.kwargs.get(key, Undefined)
-            source = "KWARGS"
+            # # if value is not Undefined, source=KWARGS
+            if not value is Undefined:
+                source = "KWARGS"
 
         # if value is still __undefined__ and config provided, will check the config for a value to use
         if value is Undefined and self.config is not None:


### PR DESCRIPTION
when run like this:
    from test_junkie.runner import Runner
    runner = Runner([ExampleTestSuite, ExampleTestSuite], html_report="report.html")
    runner.run()
some debug info print:
2024-03-13 13:04:49,131 [DEBUG] (debugger.py, debug(), 50 - MainThread) :: ============= Runtime Settings =============
2024-03-13 13:04:49,131 [DEBUG] (debugger.py, debug(), 50 - MainThread) :: Setting: test_multithreading_limit Source: KWARGS
2024-03-13 13:04:49,131 [DEBUG] (debugger.py, debug(), 50 - MainThread) :: 123Test Thread Limit: 1:(<class 'int'>)
2024-03-13 13:04:49,131 [DEBUG] (debugger.py, debug(), 50 - MainThread) :: Test Thread Limit: 1:(<class 'int'>)
2024-03-13 13:04:49,131 [DEBUG] (debugger.py, debug(), 50 - MainThread) :: Setting: suite_multithreading_limit Source: KWARGS
2024-03-13 13:04:49,131 [DEBUG] (debugger.py, debug(), 50 - MainThread) :: Suite Thread Limit: 1
================
test_multithreading_limit source is from default not from kwargs